### PR TITLE
Changes in verification of the user by the otp

### DIFF
--- a/SecureDesk_WCF_Service/Models/OTP_Verified.cs
+++ b/SecureDesk_WCF_Service/Models/OTP_Verified.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.ServiceModel;
+namespace SecureDesk_WCF_Service.Models
+{
+    [MessageContract(IsWrapped =true,WrapperName ="User OTP Verified by Service")]
+    public class OTP_Verified
+    {
+        private bool verification_result;
+        
+        [MessageHeader(Name ="User OTP Verification Result")]
+        public bool Verification_Result
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/SecureDesk_WCF_Service/SecureDesk_WCF_Service.csproj
+++ b/SecureDesk_WCF_Service/SecureDesk_WCF_Service.csproj
@@ -79,21 +79,17 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="ServiceClass\RegistrationServiceClass.svc" />
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Algorithms\Firebase_Configuration.cs" />
     <Compile Include="Algorithms\Password.cs" />
-    <Compile Include="Models\DBPassword.cs" />
+    <Compile Include="Models\DBuserKeys.cs" />
+    <Compile Include="Models\OTP_Verified.cs" />
     <Compile Include="Models\Security_Question.cs" />
     <Compile Include="Models\User.cs" />
     <Compile Include="Models\UserOtpVerification.cs" />
     <Compile Include="Models\UserRegister.cs" />
-    <Compile Include="ServiceClass\RegistrationServiceClass.svc.cs">
-      <DependentUpon>RegistrationServiceClass.svc</DependentUpon>
-    </Compile>
-    <Compile Include="Services\RegistrationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceClass\RegistrationServiceClass.svc.cs">
       <DependentUpon>RegistrationServiceClass.svc</DependentUpon>

--- a/SecureDesk_WCF_Service/ServiceClass/RegistrationServiceClass.svc.cs
+++ b/SecureDesk_WCF_Service/ServiceClass/RegistrationServiceClass.svc.cs
@@ -22,7 +22,7 @@ namespace SecureDesk_WCF_Service
     //This class uses the Percall Instance mode so each time the request will come new instance will be managed by the service
 
     [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerCall)]
-    public class RegistrationServiceClass : RegistrationService
+    public class Service1 : RegistrationService
     {
         private  IFirebaseClient client = null;
 
@@ -248,11 +248,11 @@ namespace SecureDesk_WCF_Service
             smtpClient.Send(mailMessage);
         }
 
-        public bool verifyUser(UserOtpVerification userOtpObj )
+        public OTP_Verified verifyUser(UserOtpVerification userOtpObj )
         {
             FirebaseResponse response = client.Get("SecureDesk/UserKeys/" + userOtpObj.Email_Address);
             DBuserKeys user = response.ResultAs<DBuserKeys>();
-
+            OTP_Verified verification_status = new OTP_Verified();
             byte[] secretKey = Encoding.ASCII.GetBytes(user.UserSecretKey);
             var totp = new Totp(secretKey, step: 60);
             long timeStepMatched;
@@ -275,12 +275,12 @@ namespace SecureDesk_WCF_Service
 
                 FirebaseResponse response2 = client.Update("SecureDesk/User/" + userResult.EmailAddress, updatedUser);
                 User result = response2.ResultAs<User>();
+                verification_status.Verification_Result = true;
 
-
-                return true;
+                return verification_status;
             }
-
-            return false;
+            verification_status.Verification_Result = false;
+            return verification_status;
         }
         public int getSecurePin(string email)
         {

--- a/SecureDesk_WCF_Service/Services/RegistrationService.cs
+++ b/SecureDesk_WCF_Service/Services/RegistrationService.cs
@@ -23,7 +23,7 @@ namespace SecureDesk_WCF_Service
         void sendOTP(string email);
 
         [OperationContract]
-        bool verifyUser(UserOtpVerification otpObj);
+        OTP_Verified verifyUser(UserOtpVerification otpObj);
 
         [OperationContract]
         int getSecurePin(string email);


### PR DESCRIPTION
It was required to response with the MessageContract object type when the service operation is expecting the MessageContract object type.

Error Obtained:The operation 'verifyUser' could not be loaded because it has a parameter or return type of type System.ServiceModel.Channels.Message or a type that has MessageContractAttribute and other parameters of different types. When using System.ServiceModel.Channels.Message or types with MessageContractAttribute, the method must not use any other types of parameters

Error Resolved: By changing the return type of verifyUser operation contract 